### PR TITLE
Config friendly RestTemplate for FastTokenServices

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ ZAC for information needed on the token issuers trusted for that zone.
     <dependency>
         <groupId>com.ge.predix</groupId>
         <artifactId>uaa-token-lib</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1</version>
     </dependency>
 ```    

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ge.predix</groupId>
     <artifactId>uaa-token-lib</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.1.1</version>
     <name>Predix UAA Token Library</name>
     <description>This library contains classes that help verify UAA issued JSON Web Tokens.</description>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,14 @@
     <name>Predix UAA Token Library</name>
     <description>This library contains classes that help verify UAA issued JSON Web Tokens.</description>
     <packaging>jar</packaging>
+     <!-- Project Information -->
+    <url>https://github.com/predix/spring-jwt-validation-filter</url>
+    <developers>
+        <developer>
+            <id>pdeveloper</id>
+            <name>Predix Developer</name>
+        </developer>
+    </developers>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -113,6 +121,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+     <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
     <build>
         <plugins>
             <plugin>
@@ -129,5 +147,64 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.6</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>
-

--- a/src/main/java/com/ge/predix/uaa/token/lib/FastTokenServices.java
+++ b/src/main/java/com/ge/predix/uaa/token/lib/FastTokenServices.java
@@ -2,7 +2,6 @@ package com.ge.predix.uaa.token.lib;
 
 import static com.ge.predix.uaa.token.lib.Claims.EXP;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
 import java.util.Collections;
@@ -19,7 +18,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
@@ -37,7 +35,6 @@ import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -68,15 +65,7 @@ public class FastTokenServices implements ResourceServerTokenServices {
 
     public FastTokenServices() {
         this.restTemplate = new RestTemplate();
-        ((RestTemplate) this.restTemplate).setErrorHandler(new DefaultResponseErrorHandler() {
-            @Override
-            // Ignore 400
-            public void handleError(final ClientHttpResponse response) throws IOException {
-                if (response.getRawStatusCode() != 400) {
-                    super.handleError(response);
-                }
-            }
-        });
+        ((RestTemplate) this.restTemplate).setErrorHandler(new FastTokenServicesResponseErrorHandler());
     }
 
     @Override

--- a/src/main/java/com/ge/predix/uaa/token/lib/FastTokenServicesResponseErrorHandler.java
+++ b/src/main/java/com/ge/predix/uaa/token/lib/FastTokenServicesResponseErrorHandler.java
@@ -1,0 +1,19 @@
+package com.ge.predix.uaa.token.lib;
+
+import java.io.IOException;
+
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+
+public class FastTokenServicesResponseErrorHandler extends DefaultResponseErrorHandler {
+    /* (non-Javadoc)
+     * @see org.springframework.web.client.DefaultResponseErrorHandler#handleError(org.springframework.http.client.ClientHttpResponse)
+     * We overrode this method to ignore 400 errors.
+     */
+    @Override
+    public void handleError(final ClientHttpResponse response) throws IOException {
+        if (response.getRawStatusCode() != 400) {
+            super.handleError(response);
+        }
+    }
+}


### PR DESCRIPTION
Previously, the default RestTemplate for FastTokenServices was using an anonymous class for some custom error handling. I moved this anonymous class into a separate class so anyone who wants to inject a custom RestTemplate into FastTokenServices can reuse the same error handling.