### PR TITLE
Add support for multiple default issuers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ge.predix</groupId>
     <artifactId>uaa-token-lib</artifactId>
-    <version>3.1.4-SNAPSHOT</version>
+    <version>3.1.5-SNAPSHOT</version>
     <name>Predix UAA Token Library</name>
     <description>This library contains classes that help verify UAA issued JSON Web Tokens.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/ge/predix/uaa/token/lib/AbstractZoneAwareTokenService.java
+++ b/src/main/java/com/ge/predix/uaa/token/lib/AbstractZoneAwareTokenService.java
@@ -91,8 +91,7 @@ public abstract class AbstractZoneAwareTokenService implements ResourceServerTok
     private OAuth2Authentication authenticateNonZoneSpecificRequest(final String accessToken) {
         OAuth2Authentication authentication;
         if (this.defaultFastTokenService == null) {
-            this.defaultFastTokenService = createFastTokenService(
-                    Arrays.asList(this.defaultZoneConfig.getTrustedIssuerId()));
+            this.defaultFastTokenService = createFastTokenService(this.defaultZoneConfig.getTrustedIssuerIds());
         }
         authentication = this.defaultFastTokenService.loadAuthentication(accessToken);
         return authentication;

--- a/src/main/java/com/ge/predix/uaa/token/lib/DefaultZoneConfiguration.java
+++ b/src/main/java/com/ge/predix/uaa/token/lib/DefaultZoneConfiguration.java
@@ -15,22 +15,27 @@
  *******************************************************************************/
 package com.ge.predix.uaa.token.lib;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.util.AntPathMatcher;
 
-public class DefaultZoneConfiguration {
+public class DefaultZoneConfiguration implements InitializingBean {
     private String trustedIssuerId;
     private List<String> allowedUriPatterns;
+    private List<String> trustedIssuerIds = new ArrayList<>();
 
     public String getTrustedIssuerId() {
         return this.trustedIssuerId;
     }
 
-    @Required
     public void setTrustedIssuerId(final String trustedIssuerId) {
         this.trustedIssuerId = trustedIssuerId;
+        // providing default behavior for existing single issuer contract
+        this.trustedIssuerIds.add(trustedIssuerId);
     }
 
     /**
@@ -54,4 +59,22 @@ public class DefaultZoneConfiguration {
         this.allowedUriPatterns = allowedUriPatterns;
     }
 
+    public List<String> getTrustedIssuerIds() {
+        return this.trustedIssuerIds;
+    }
+
+    public void setTrustedIssuerIds(final List<String> trustedIssuerIds) {
+        this.trustedIssuerIds = new ArrayList<>(trustedIssuerIds);
+        // providing default behavior for existing single issuer contract
+        if (this.trustedIssuerIds != null && this.trustedIssuerIds.size() > 0) {
+            this.trustedIssuerId = this.trustedIssuerIds.get(0);
+        }
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        if (this.trustedIssuerIds == null || this.trustedIssuerIds.size() == 0) {
+            throw new BeanCreationException("DefaultZoneConfiguration requires a default trusted Issuer");
+        }
+    }
 }

--- a/src/test/java/com/ge/predix/uaa/token/lib/DefaultZoneConfiguratorTest.java
+++ b/src/test/java/com/ge/predix/uaa/token/lib/DefaultZoneConfiguratorTest.java
@@ -1,0 +1,60 @@
+package com.ge.predix.uaa.token.lib;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test
+public class DefaultZoneConfiguratorTest {
+
+    @Test(dataProvider = "validAllowedPatters")
+    public void testValidAllowedPatters(final List<String> allowedUriPatterns) {
+        DefaultZoneConfiguration configurator = new DefaultZoneConfiguration();
+        configurator.setAllowedUriPatterns(allowedUriPatterns);
+
+        Assert.assertEquals(configurator.getAllowedUriPatterns(), allowedUriPatterns);
+    }
+
+    @Test(dataProvider = "invalidAllowedPatters", expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidAllowedPatters(final List<String> allowedUriPatterns) {
+        DefaultZoneConfiguration configurator = new DefaultZoneConfiguration();
+        configurator.setAllowedUriPatterns(allowedUriPatterns);
+    }
+
+    public void testSingleTrustedIssuer() {
+        String expectedIssuer = "http://uaa.predix.com";
+        DefaultZoneConfiguration configurator = new DefaultZoneConfiguration();
+        configurator.setTrustedIssuerId(expectedIssuer);
+
+        Assert.assertEquals(configurator.getTrustedIssuerId(), expectedIssuer);
+        // asserting default behavior for existing single issuer contract
+        Assert.assertEquals(configurator.getTrustedIssuerIds().iterator().next(), expectedIssuer);
+    }
+
+    public void testMultipleTrustedIssuers() {
+        List<String> expectedIssuers = Arrays.asList("http://uaa.predix.com", "http://zac-uaa.predix.com");
+        DefaultZoneConfiguration configurator = new DefaultZoneConfiguration();
+        configurator.setTrustedIssuerIds(expectedIssuers);
+
+        Assert.assertEquals(configurator.getTrustedIssuerIds(), expectedIssuers);
+        // asserting default behavior for existing single issuer contract
+        Assert.assertEquals(configurator.getTrustedIssuerId(), expectedIssuers.get(0));
+    }
+
+    @DataProvider
+    private Object[][] validAllowedPatters() {
+
+        return new Object[][] { { new ArrayList<String>() }, { Arrays.asList("/zone/**") },
+                { Arrays.asList("/zone/?") }, };
+    }
+
+    @DataProvider
+    private Object[][] invalidAllowedPatters() {
+
+        return new Object[][] { { Arrays.asList("/zone") }, { Arrays.asList("abc") }, };
+    }
+}


### PR DESCRIPTION
This PR is to add supports for multiple default issuers.

* DefaultZoneConfiguration supports the trustedIssuerIds property in addition to the trustedIssuerId.
* Changes are backward compatible with the single trustedIssuerId, configuration and everything else should work.
* A small change in the AbstractZoneAwareTokenService was needed to use the new trustedIssuerIds property.