### PR TITLE
Clarify authorization failure when token has insufficient scope

### DIFF
--- a/src/main/java/com/ge/predix/uaa/token/lib/AbstractZoneAwareTokenService.java
+++ b/src/main/java/com/ge/predix/uaa/token/lib/AbstractZoneAwareTokenService.java
@@ -147,8 +147,8 @@ public abstract class AbstractZoneAwareTokenService implements ResourceServerTok
         if (!authenticationAuthorities.contains(new SimpleGrantedAuthority(expectedScope))) {
             LOGGER.debug("Invalid token scope. Did not find expected scope: " + expectedScope);
             // This exception is translated to HTTP 401. InsufficientAuthenticationException results in 500
-            throw new InvalidTokenException(String.format("Unauthorized zone access by principal: %s for zone: %s",
-                    authentication.getPrincipal(), zoneId));
+            throw new InvalidTokenException(String.format("Unauthorized zone access by principal: '%s' for zone: '%s' "
+                    + ", due to insufficient scope.", authentication.getPrincipal(), zoneId));
         }
     }
 


### PR DESCRIPTION
this came out of a user post on forum:  https://forum.predix.io/questions/15553/acs-issue-with-multiple-trustissuerids.html#comment-15693