### PR TITLE
DE54258: Throw InvalidTokenException if token claims don't contain va…

### DIFF
--- a/src/main/java/com/ge/predix/uaa/token/lib/FastTokenServices.java
+++ b/src/main/java/com/ge/predix/uaa/token/lib/FastTokenServices.java
@@ -180,10 +180,16 @@ public class FastTokenServices implements ResourceServerTokenServices {
         }
     }
 
-    private void verifyTimeWindow(final Map<String, Object> claims) {
+    void verifyTimeWindow(final Map<String, Object> claims) {
 
-        Date iatDate = getIatDate(claims);
-        Date expDate = getExpDate(claims);
+        Date iatDate = null;
+        Date expDate = null;
+        try {
+            iatDate = getIatDate(claims);
+            expDate = getExpDate(claims);
+        } catch (Exception e) {
+            throw new InvalidTokenException("Unable to determine token validity window.");
+        }
 
         Date currentDate = new Date();
         if (iatDate != null && iatDate.after(currentDate)) {
@@ -199,14 +205,14 @@ public class FastTokenServices implements ResourceServerTokenServices {
         }
     }
 
-    protected Date getIatDate(final Map<String, Object> claims) {
-        Integer iat = (Integer) claims.get(Claims.IAT);
-        return new Date((iat.longValue() - this.maxAcceptableClockSkewSeconds) * 1000L);
+    private Date getIatDate(final Map<String, Object> claims) {
+        long iat = Long.valueOf(claims.get(Claims.IAT).toString());
+        return new Date((iat - this.maxAcceptableClockSkewSeconds) * 1000L);
     }
 
-    protected Date getExpDate(final Map<String, Object> claims) {
-        Integer exp = (Integer) claims.get(Claims.EXP);
-        return new Date((exp.longValue() + this.maxAcceptableClockSkewSeconds) * 1000L);
+    private Date getExpDate(final Map<String, Object> claims) {
+        long exp = Long.valueOf(claims.get(Claims.EXP).toString());
+        return new Date((exp + this.maxAcceptableClockSkewSeconds) * 1000L);
     }
 
     protected String getTokenKey(final String issuer) {

--- a/src/test/java/com/ge/predix/uaa/token/lib/FastTokenServiceTest.java
+++ b/src/test/java/com/ge/predix/uaa/token/lib/FastTokenServiceTest.java
@@ -51,8 +51,6 @@ public class FastTokenServiceTest {
 
     private final FastTokenServices services;
 
-    private final Map<String, Object> body = new HashMap<>();
-
     public FastTokenServiceTest() throws Exception {
         this.services = new FastTokenServices();
         this.services.setRestTemplate(mockRestTemplate());
@@ -215,6 +213,14 @@ public class FastTokenServiceTest {
         assertEquals("https://localhost:8080/uaa/token_key", this.services.getTokenKeyURL(TOKEN_ISSUER_ID));
 
         assertEquals("https://sample.com/token_key", this.services.getTokenKeyURL("https://sample.com/oauth/token"));
+    }
+
+    @Test(expectedExceptions = InvalidTokenException.class)
+    public void testVerifyTimeWindowException() {
+        Map<String, Object> claims = new HashMap<String, Object>();
+        claims.put(Claims.IAT, "not-an-expected-long");
+        claims.put(Claims.EXP, "not-an-expected-long");
+        this.services.verifyTimeWindow(claims);
     }
 
 }


### PR DESCRIPTION
…lid 'issued at' and 'expiration' dates.