### PR TITLE
Add resource id validation

### DIFF
--- a/src/test/java/com/ge/predix/uaa/token/lib/TestTokenUtil.java
+++ b/src/test/java/com/ge/predix/uaa/token/lib/TestTokenUtil.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -165,7 +164,7 @@ public class TestTokenUtil {
                 .expirationTime(Date.from(now.plus(validityMinutes, ChronoUnit.MINUTES))) // 1 hour expiration
                 .claim(SCOPE, requestedScopes)
                 .claim(CID, clientId)
-
+                .claim(AUTHORITIES, List.of("uaa.resource", "test.resource"))
                 .claim(ZONE_ID, zoneId)
                 .claim(EMAIL, userEmail)
                 .claim(USER_ID, userId)


### PR DESCRIPTION
As the latest Spring Security framework does not support resource ID validation, incorporate this functionality as an optional feature in the fast token service.
This way, users who require it can enable it by setting the resource ID value.