### PR TITLE
Fix out of memory error

### DIFF
--- a/src/test/java/com/ge/predix/uaa/token/lib/ZacTokenServiceTest.java
+++ b/src/test/java/com/ge/predix/uaa/token/lib/ZacTokenServiceTest.java
@@ -305,6 +305,7 @@ public class ZacTokenServiceTest {
         zoneConfig.setTrustedIssuerIds(trustedIssuers);
 
         ClientRegistration mockRegistration = mock(ClientRegistration.class);
+        when(mockRegistration.getRegistrationId()).thenReturn("testClientRegistrationId");
         ZacTokenService zacTokenServices = new ZacTokenService(SERVICEID, zoneConfig, "", request, mockRegistration);
         zacTokenServices.setServiceZoneHeaders(configuredHeaderNames);
         zacTokenServices.setFastRemoteTokenServicesCreator(mockFTSC);


### PR DESCRIPTION
Refactor ZacTokenService to fix out of memory error and move Rest client creation to the constructor to avoid it is being created each time of the API calls.